### PR TITLE
bugfix: password resets

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/utils.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/utils.py
@@ -101,6 +101,6 @@ def generate_password_reset_token(email: str) -> str:
 def verify_password_reset_token(token: str) -> Optional[str]:
     try:
         decoded_token = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
-        return decoded_token["email"]
+        return decoded_token["sub"]
     except jwt.JWTError:
         return None


### PR DESCRIPTION
Use the same dictionary key for encoding/decoding password reset tokens, otherwise `decoded_token['email']` raises a key error.